### PR TITLE
After rate limit reached stop processing

### DIFF
--- a/MvcThrottle/ThrottlingFilter.cs
+++ b/MvcThrottle/ThrottlingFilter.cs
@@ -163,6 +163,8 @@ namespace MvcThrottle
                                 string.Format(message, rateLimit, rateLimitPeriod),
                                 QuotaExceededResponseCode,
                                 requestId);
+                                
+                            return;
                         }
                     }
                 }


### PR DESCRIPTION
Once a rate limit is reached the remaining rates should not be evaluated. This restores the behaviour that is described in the readme,  regarding stacked requests.