### PR TITLE
Added User-Agent blacklist based throttling

### DIFF
--- a/MvcThrottle/RequestIdentity.cs
+++ b/MvcThrottle/RequestIdentity.cs
@@ -15,6 +15,7 @@ namespace MvcThrottle
         public string ClientIp { get; set; }
         public string ClientKey { get; set; }
         public string Endpoint { get; set; }
+        public string UserAgent { get; set; }
 
         public override string ToString()
         {

--- a/MvcThrottle/ThrottleLogEntry.cs
+++ b/MvcThrottle/ThrottleLogEntry.cs
@@ -13,6 +13,7 @@ namespace MvcThrottle
         public string RequestId { get; set; }
         public string ClientIp { get; set; }
         public string ClientKey { get; set; }
+        public string UserAgent { get; set; }
         public string Endpoint { get; set; }
         public long TotalRequests { get; set; }
         public DateTime StartPeriod { get; set; }

--- a/MvcThrottle/ThrottlePolicy.cs
+++ b/MvcThrottle/ThrottlePolicy.cs
@@ -35,6 +35,13 @@ namespace MvcThrottle
         public EndpointThrottlingType EndpointType { get; set; }
 
         /// <summary>
+        /// Enables User-Agent throttling
+        /// </summary>
+        public bool UserAgentThrottling { get; set; }
+        public List<string> UserAgentBlacklist { get; set; }
+        public Dictionary<string, RateLimits> UserAgentRules { get; set; }
+
+        /// <summary>
         /// All requests including the rejected ones will stack in this order: week, day, hour, min, sec
         /// </summary>
         public bool StackBlockedRequests { get; set; }


### PR DESCRIPTION
This can be used to aggressively throttle specific bots.
Example:

```
var throttleFilter = new ThrottlingFilter
{
    Policy = new ThrottlePolicy(perSecond: 1, perMinute: 10, perHour: 60 * 10, perDay: 600 * 10)
    {
        IpThrottling = true,
        UserAgentThrottling = true,
        UserAgentBlacklist = new List<string> { "AhrefsBot", "Yahoo! Slurp" },
        UserAgentRules = new Dictionary<string, RateLimits>
        {
            { "AhrefsBot", new RateLimits { PerSecond = 1, PerMinute = 3 } },
            { "Yahoo! Slurp", new RateLimits { PerSecond = 1, PerMinute = 5 } }
        }
    },
    Repository = new CacheRepository()
};
```
