### PR TITLE
Made EnableThrottlingAttribute.GetLimit() a virtual method so that it can be overridden in subclasses

### DIFF
--- a/MvcThrottle/ThrottingAttributes.cs
+++ b/MvcThrottle/ThrottingAttributes.cs
@@ -15,7 +15,7 @@ namespace MvcThrottle
         public long PerDay { get; set; }
         public long PerWeek { get; set; }
 
-        public long GetLimit(RateLimitPeriod period)
+        public virtual long GetLimit(RateLimitPeriod period)
         {
             switch (period)
             {


### PR DESCRIPTION
Having the GetLimit() method in EnableThrottlingAttribute be virtual really helps with creating subclasses that inherit EnableThrottlingAttribute.

I created class that inherited EnableThrottlingAttribute, where I defined a throttling policy at compile time. At runtime, it pulls the throttling policy from the web.config file. In order to make this work, I had to make GetLimit() virtual and override it, reading the limit settings from the configuration.
